### PR TITLE
fix: archive feature fails on no_std builds

### DIFF
--- a/crates/tinywasm/src/func.rs
+++ b/crates/tinywasm/src/func.rs
@@ -37,9 +37,9 @@ impl FuncHandle {
         }
 
         // 5. For each value type and the corresponding value, check if types match
-        if !(func_ty.params.iter().zip(params).enumerate().all(|(i, (ty, param))| {
+        if !(func_ty.params.iter().zip(params).enumerate().all(|(_i, (ty, param))| {
             if ty != &param.val_type() {
-                log::error!("param type mismatch at index {}: expected {:?}, got {:?}", i, ty, param);
+                log::error!("param type mismatch at index {}: expected {:?}, got {:?}", _i, ty, param);
                 false
             } else {
                 true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,10 +11,10 @@ rust-version.workspace=true
 [dependencies]
 log={workspace=true, optional=true}
 rkyv={version="0.7", optional=true, default-features=false, features=["size_32", "validation"]}
-bytecheck={version="0.7", optional=true}
+bytecheck={version="0.7", optional=true, default-features=false}
 
 [features]
 default=["std", "logging", "archive"]
-std=["rkyv?/std"]
+std=["rkyv?/std", "bytecheck?/std"]
 archive=["dep:rkyv", "dep:bytecheck"]
 logging=["dep:log"]


### PR DESCRIPTION
Bytecheck std feature is enabled by default, change it to the same behavior as rkyv. 
Also fix a warning when building with logging disabled.

