### PR TITLE
feat: serde serialization and deserialization support for TinyWasmModule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ version = "0.9.0-alpha.0"
 dependencies = [
  "log",
  "rkyv",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -167,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +221,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -237,6 +264,18 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_logger"
@@ -278,10 +317,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -375,6 +437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +504,19 @@ name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -585,6 +670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +692,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -642,6 +742,21 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -694,10 +809,12 @@ version = "0.9.0-alpha.0"
 dependencies = [
  "criterion",
  "eyre",
+ "heapless",
  "indexmap",
  "libm",
  "log",
  "owo-colors",
+ "postcard",
  "pretty_env_logger",
  "serde",
  "serde_json",

--- a/crates/tinywasm/Cargo.toml
+++ b/crates/tinywasm/Cargo.toml
@@ -30,9 +30,11 @@ criterion={workspace=true}
 owo-colors={version="4.0"}
 serde_json={version="1.0"}
 serde={version="1.0", features=["derive"]}
+postcard={version="1.1.1", features = ["use-std"]}
+heapless="0.7.17"
 
 [features]
-default=["std", "parser", "logging", "archive"]
+default=["std", "parser", "logging", "archive", "serde"]
 logging=["log", "tinywasm-parser?/logging", "tinywasm-types/logging"]
 std=["tinywasm-parser?/std", "tinywasm-types/std"]
 parser=["dep:tinywasm-parser"]

--- a/crates/tinywasm/Cargo.toml
+++ b/crates/tinywasm/Cargo.toml
@@ -37,6 +37,7 @@ logging=["log", "tinywasm-parser?/logging", "tinywasm-types/logging"]
 std=["tinywasm-parser?/std", "tinywasm-types/std"]
 parser=["dep:tinywasm-parser"]
 archive=["tinywasm-types/archive"]
+serde=["tinywasm-types/serde"]
 
 [[test]]
 name="test-wasm-1"

--- a/crates/tinywasm/benches/argon2id.rs
+++ b/crates/tinywasm/benches/argon2id.rs
@@ -16,8 +16,18 @@ fn argon2id_to_twasm(module: TinyWasmModule) -> Result<AlignedVec> {
     Ok(twasm)
 }
 
+fn argon2id_to_postcard_wasm(module: TinyWasmModule) -> Result<Vec<u8>> {
+    let postcard_wasm = postcard::to_stdvec(&module)?;
+    Ok(postcard_wasm)
+}
+
 fn argon2id_from_twasm(twasm: AlignedVec) -> Result<TinyWasmModule> {
     let module = TinyWasmModule::from_twasm(&twasm)?;
+    Ok(module)
+}
+
+fn argon2id_from_postcard_wasm(postcard_wasm: Vec<u8>) -> Result<TinyWasmModule> {
+    let module = postcard::from_bytes(&postcard_wasm)?;
     Ok(module)
 }
 
@@ -32,10 +42,13 @@ fn argon2id_run(module: TinyWasmModule) -> Result<()> {
 fn criterion_benchmark(c: &mut Criterion) {
     let module = argon2id_parse().expect("argon2id_parse");
     let twasm = argon2id_to_twasm(module.clone()).expect("argon2id_to_twasm");
+    let postcard_wasm = argon2id_to_postcard_wasm(module.clone()).expect("argon2id_to_postcard_wasm");
 
     c.bench_function("argon2id_parse", |b| b.iter(argon2id_parse));
     c.bench_function("argon2id_to_twasm", |b| b.iter(|| argon2id_to_twasm(module.clone())));
+    c.bench_function("argon2id_to_postcard_wasm", |b| b.iter(|| argon2id_to_postcard_wasm(module.clone())));
     c.bench_function("argon2id_from_twasm", |b| b.iter(|| argon2id_from_twasm(twasm.clone())));
+    c.bench_function("argon2id_from_postcard_wasm", |b| b.iter(|| argon2id_from_postcard_wasm(postcard_wasm.clone())));
     c.bench_function("argon2id", |b| b.iter(|| argon2id_run(module.clone())));
 }
 

--- a/crates/tinywasm/benches/fibonacci.rs
+++ b/crates/tinywasm/benches/fibonacci.rs
@@ -16,8 +16,18 @@ fn fibonacci_to_twasm(module: TinyWasmModule) -> Result<AlignedVec> {
     Ok(twasm)
 }
 
+fn fibonacci_to_postcard_wasm(module: TinyWasmModule) -> Result<Vec<u8>> {
+    let postcard_wasm = postcard::to_stdvec(&module)?;
+    Ok(postcard_wasm)
+}
+
 fn fibonacci_from_twasm(twasm: AlignedVec) -> Result<TinyWasmModule> {
     let module = TinyWasmModule::from_twasm(&twasm)?;
+    Ok(module)
+}
+
+fn fibonacci_from_postcard_wasm(postcard_wasm: Vec<u8>) -> Result<TinyWasmModule> {
+    let module = postcard::from_bytes(&postcard_wasm)?;
     Ok(module)
 }
 
@@ -38,10 +48,15 @@ fn fibonacci_run(module: TinyWasmModule, recursive: bool, n: i32) -> Result<()> 
 fn criterion_benchmark(c: &mut Criterion) {
     let module = fibonacci_parse().expect("fibonacci_parse");
     let twasm = fibonacci_to_twasm(module.clone()).expect("fibonacci_to_twasm");
+    let postcard_wasm = fibonacci_to_postcard_wasm(module.clone()).expect("fibonacci_to_postcard_wasm");
 
     c.bench_function("fibonacci_parse", |b| b.iter(fibonacci_parse));
     c.bench_function("fibonacci_to_twasm", |b| b.iter(|| fibonacci_to_twasm(module.clone())));
+    c.bench_function("fibonacci_to_postcard_wasm", |b| b.iter(|| fibonacci_to_postcard_wasm(module.clone())));
     c.bench_function("fibonacci_from_twasm", |b| b.iter(|| fibonacci_from_twasm(twasm.clone())));
+    c.bench_function("fibonacci_from_postcard_wasm", |b| {
+        b.iter(|| fibonacci_from_postcard_wasm(postcard_wasm.clone()))
+    });
     c.bench_function("fibonacci_iterative_60", |b| b.iter(|| fibonacci_run(module.clone(), false, 60)));
     c.bench_function("fibonacci_recursive_26", |b| b.iter(|| fibonacci_run(module.clone(), true, 26)));
 }

--- a/crates/tinywasm/benches/tinywasm.rs
+++ b/crates/tinywasm/benches/tinywasm.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use eyre::Result;
+use heapless::Vec as HeapLessVec;
 use tinywasm::{types, Extern, FuncContext, Imports, ModuleInstance, Store};
 use types::{archive::AlignedVec, TinyWasmModule};
 
@@ -16,8 +17,18 @@ fn tinywasm_to_twasm(module: TinyWasmModule) -> Result<AlignedVec> {
     Ok(twasm)
 }
 
+fn tinywasm_to_postcard_wasm(module: TinyWasmModule) -> Result<Vec<u8>> {
+    let postcard_wasm = postcard::to_stdvec(&module)?;
+    Ok(postcard_wasm)
+}
+
 fn tinywasm_from_twasm(twasm: AlignedVec) -> Result<TinyWasmModule> {
     let module = TinyWasmModule::from_twasm(&twasm)?;
+    Ok(module)
+}
+
+fn tinywasm_from_postcard_wasm(postcard_wasm: Vec<u8>) -> Result<TinyWasmModule> {
+    let module = postcard::from_bytes(&postcard_wasm)?;
     Ok(module)
 }
 
@@ -34,10 +45,13 @@ fn tinywasm_run(module: TinyWasmModule) -> Result<()> {
 fn criterion_benchmark(c: &mut Criterion) {
     let module = tinywasm_parse().expect("tinywasm_parse");
     let twasm = tinywasm_to_twasm(module.clone()).expect("tinywasm_to_twasm");
+    let postcard_wasm = tinywasm_to_postcard_wasm(module.clone()).expect("tinywasm_to_postcard_wasm");
 
     c.bench_function("tinywasm_parse", |b| b.iter(tinywasm_parse));
     c.bench_function("tinywasm_to_twasm", |b| b.iter(|| tinywasm_to_twasm(module.clone())));
+    c.bench_function("tinywasm_to_postcard_wasm", |b| b.iter(|| tinywasm_to_postcard_wasm(module.clone())));
     c.bench_function("tinywasm_from_twasm", |b| b.iter(|| tinywasm_from_twasm(twasm.clone())));
+    c.bench_function("tinywasm_from_postcard_wasm", |b| b.iter(|| tinywasm_from_postcard_wasm(postcard_wasm.clone())));
     c.bench_function("tinywasm", |b| b.iter(|| tinywasm_run(module.clone())));
 }
 

--- a/crates/tinywasm/src/interpreter/stack/block_stack.rs
+++ b/crates/tinywasm/src/interpreter/stack/block_stack.rs
@@ -8,7 +8,7 @@ pub(crate) struct BlockStack(Vec<BlockFrame>);
 
 impl Default for BlockStack {
     fn default() -> Self {
-        Self(Vec::with_capacity(128))
+        Self(Vec::with_capacity(0))
     }
 }
 

--- a/crates/tinywasm/src/interpreter/stack/value_stack.rs
+++ b/crates/tinywasm/src/interpreter/stack/value_stack.rs
@@ -4,9 +4,9 @@ use tinywasm_types::{ExternRef, FuncRef, ValType, ValueCounts, ValueCountsSmall,
 use crate::{interpreter::*, Result};
 
 use super::Locals;
-pub(crate) const STACK_32_SIZE: usize = 1024 * 32;
-pub(crate) const STACK_64_SIZE: usize = 1024 * 16;
-pub(crate) const STACK_128_SIZE: usize = 1024 * 8;
+pub(crate) const STACK_32_SIZE: usize = 1024;
+pub(crate) const STACK_64_SIZE: usize = 1024;
+pub(crate) const STACK_128_SIZE: usize = 1024;
 pub(crate) const STACK_REF_SIZE: usize = 1024;
 
 #[derive(Debug)]
@@ -20,10 +20,10 @@ pub(crate) struct ValueStack {
 impl ValueStack {
     pub(crate) fn new() -> Self {
         Self {
-            stack_32: Vec::with_capacity(STACK_32_SIZE),
-            stack_64: Vec::with_capacity(STACK_64_SIZE),
-            stack_128: Vec::with_capacity(STACK_128_SIZE),
-            stack_ref: Vec::with_capacity(STACK_REF_SIZE),
+            stack_32: Vec::with_capacity(0),
+            stack_64: Vec::with_capacity(0),
+            stack_128: Vec::with_capacity(0),
+            stack_ref: Vec::with_capacity(0),
         }
     }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,9 +11,11 @@ rust-version.workspace=true
 [dependencies]
 log={workspace=true, optional=true}
 rkyv={version="0.8.1", optional=true, default-features=false, features=["alloc", "bytecheck"]}
+serde={version="1.0.0", optional=true, default-features=false, features=["derive","alloc"]}
 
 [features]
 default=["std", "logging", "archive"]
 std=["rkyv?/std"]
+serde=["dep:serde"]
 archive=["dep:rkyv"]
 logging=["dep:log"]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -15,7 +15,7 @@ serde={version="1.0.0", optional=true, default-features=false, features=["derive
 
 [features]
 default=["std", "logging", "archive"]
-std=["rkyv?/std"]
+std=["rkyv?/std", "serde?/std"]
 serde=["dep:serde"]
 archive=["dep:rkyv"]
 logging=["dep:log"]

--- a/crates/types/src/instructions.rs
+++ b/crates/types/src/instructions.rs
@@ -4,6 +4,7 @@ use crate::{ConstIdx, DataAddr, ElemAddr, ExternAddr, MemAddr};
 /// Represents a memory immediate in a WebAssembly memory instruction.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 
 pub struct MemoryArg([u8; 12]);
 
@@ -31,6 +32,7 @@ type ElseOffset = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConstInstruction {
     I32Const(i32),
     I64Const(i64),
@@ -54,6 +56,7 @@ pub enum ConstInstruction {
 /// See <https://webassembly.github.io/spec/core/binary/instructions.html>
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 // should be kept as small as possible (16 bytes max)
 #[rustfmt::skip]
 pub enum Instruction {
@@ -195,6 +198,7 @@ impl From<SimdInstruction> for Instruction {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[rustfmt::skip] 
 pub enum SimdInstruction { 
     V128Load(MemoryArg),

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -52,6 +52,7 @@ pub mod archive;
 /// This means you should not trust a `TinyWasmModule` created by a third party to be valid.
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TinyWasmModule {
     /// Optional address of the start function
     ///
@@ -109,6 +110,7 @@ pub struct TinyWasmModule {
 /// See <https://webassembly.github.io/spec/core/syntax/types.html#external-types>
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExternalKind {
     /// A WebAssembly Function.
     Func,
@@ -181,6 +183,7 @@ impl ExternVal {
 /// See <https://webassembly.github.io/spec/core/syntax/types.html#function-types>
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FuncType {
     pub params: Box<[ValType]>,
     pub results: Box<[ValType]>,
@@ -188,6 +191,7 @@ pub struct FuncType {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueCounts {
     pub c32: u32,
     pub c64: u32,
@@ -197,6 +201,7 @@ pub struct ValueCounts {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueCountsSmall {
     pub c32: u16,
     pub c64: u16,
@@ -236,6 +241,7 @@ impl<'a, T: IntoIterator<Item = &'a ValType>> From<T> for ValueCountsSmall {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WasmFunction {
     pub instructions: Box<[Instruction]>,
     pub data: WasmFunctionData,
@@ -246,6 +252,7 @@ pub struct WasmFunction {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WasmFunctionData {
     pub v128_constants: Box<[u128]>,
 }
@@ -253,6 +260,7 @@ pub struct WasmFunctionData {
 /// A WebAssembly Module Export
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Export {
     /// The name of the export.
     pub name: Box<str>,
@@ -264,6 +272,7 @@ pub struct Export {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Global {
     pub ty: GlobalType,
     pub init: ConstInstruction,
@@ -271,6 +280,7 @@ pub struct Global {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GlobalType {
     pub mutable: bool,
     pub ty: ValType,
@@ -278,6 +288,7 @@ pub struct GlobalType {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableType {
     pub element_type: ValType,
     pub size_initial: u32,
@@ -297,6 +308,7 @@ impl TableType {
 /// Represents a memory's type.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryType {
     arch: MemoryArch,
     page_count_initial: u64,
@@ -336,6 +348,7 @@ impl MemoryType {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MemoryArch {
     I32,
     I64,
@@ -343,6 +356,7 @@ pub enum MemoryArch {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Import {
     pub module: Box<str>,
     pub name: Box<str>,
@@ -351,6 +365,7 @@ pub struct Import {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ImportKind {
     Function(TypeAddr),
     Table(TableType),
@@ -372,6 +387,7 @@ impl From<&ImportKind> for ExternalKind {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Data {
     pub data: Box<[u8]>,
     pub range: Range<usize>,
@@ -380,6 +396,7 @@ pub struct Data {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataKind {
     Active { mem: MemAddr, offset: ConstInstruction },
     Passive,
@@ -387,6 +404,7 @@ pub enum DataKind {
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Element {
     pub kind: ElementKind,
     pub items: Box<[ElementItem]>,
@@ -396,6 +414,7 @@ pub struct Element {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ElementKind {
     Passive,
     Active { table: TableAddr, offset: ConstInstruction },
@@ -404,6 +423,7 @@ pub enum ElementKind {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ElementItem {
     Func(FuncAddr),
     Expr(ConstInstruction),

--- a/crates/types/src/value.rs
+++ b/crates/types/src/value.rs
@@ -250,6 +250,7 @@ impl WasmValue {
 /// Type of a WebAssembly value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "archive", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ValType {
     /// A 32-bit integer.
     I32,


### PR DESCRIPTION
This adds serde support to TinyWasmModule as discussed in https://github.com/explodingcamera/tinywasm/issues/31. It doesn't pull any specific de/serialization format yet. No TinyWasmModule changes where need for enabling that.
I will add later some benchmarks serde+postcard vs rkyv.
